### PR TITLE
Fix for smtp-servers using SSL

### DIFF
--- a/wallabag_kindle_consumer/sender.py
+++ b/wallabag_kindle_consumer/sender.py
@@ -37,8 +37,7 @@ class Sender:
 
         msg.attach(mobi)
 
-        smtp = smtplib.SMTP(host=self.host, port=self.port)
-        smtp.starttls()
+        smtp = smtplib.SMTP_SSL(host=self.host, port=self.port)
         if self.user is not None:
             smtp.login(self.user, self.passwd)
         smtp.sendmail(self.from_addr, [email], msg.as_string())


### PR DESCRIPTION
Fix for smtp-servers using SSL, works with gmail.com, yandex.ru and other public servers with ssl. Variant with smtplib.SMTP doesn't work with smtp.yandex.ru (popular public mail provider in Russia, something like google, but local) returning "SMTPServerDisconnected: Connection unexpectedly closed" error, same with gmail. Seems like SSL is everywhere nowdays, so should work most modern smtp servers.