### PR TITLE
Sending Username and Password in HTTP POST request

### DIFF
--- a/wallabag_kindle_consumer/wallabag.py
+++ b/wallabag_kindle_consumer/wallabag.py
@@ -45,7 +45,7 @@ class Wallabag:
                   'password': passwd}
 
         async with aiohttp.ClientSession() as session:
-            async with session.get(self._url('/oauth/v2/token'), params=params) as resp:
+            async with session.post(self._url('/oauth/v2/token'), json=params) as resp:
                 if resp.status != 200:
                     logger.warn("Cannot get token for user {user}", user=user.name)
                     return False
@@ -65,7 +65,7 @@ class Wallabag:
                   'username': user.name}
 
         async with aiohttp.ClientSession() as session:
-            async with session.get(self._url('/oauth/v2/token'), params=params) as resp:
+            async with session.post(self._url('/oauth/v2/token'), json=params) as resp:
                 if resp.status != 200:
                     logger.warn("Cannot refresh token for user {user}", user=user.name)
                     return False


### PR DESCRIPTION
Hello, 
I found that when I used this tool to check for articles and refresh its tokens, I could see sensitive information like username and password in Wallabag logs. 
I changed the methods that produced these HTTP requests to send their sensitive data in the body of a HTTP POST request, and everything still works without a problem.